### PR TITLE
Reset the `trap` INT signal in `colorssh`

### DIFF
--- a/oh-my-zsh/iTrem2-ssh.zsh
+++ b/oh-my-zsh/iTrem2-ssh.zsh
@@ -22,6 +22,7 @@ function colorssh() {
         fi
     fi
     ssh $*
+    trap - INT
 }
 compdef _ssh tabc=ssh
 


### PR DESCRIPTION
**Bug repro steps:**
- Run `ssh ...` (i.e. colorssh) and exit
- BUG: See that CTRL+C no longer works in the current shell


---

This PR is based on this stack exchange question/answer: https://superuser.com/questions/1178934/iterm2-ctrl-c-doesnt-work-sometimes

If you believe this should be merged, it's probably also worth updating the blog post: https://coderwall.com/p/t7a-tq/change-terminal-color-when-ssh-from-os-x